### PR TITLE
add files to build tomo_tv in a docker image

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,0 +1,56 @@
+# docker build . -t peterercius/tomo_tv
+# docker push peterercius/tomo_tv:latest
+
+FROM nvidia/cuda:11.7.1-cudnn8-devel-ubuntu20.04
+
+RUN  apt-get update \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get install -yq wget git vim autotools-dev automake libtool libboost-all-dev python3-pip \
+  && rm -rf /var/lib/apt/lists/* \
+  && ln -s /usr/bin/python3 /usr/bin/python
+
+RUN git clone --recursive https://github.com/jtschwar/tomo_TV.git \
+  && git clone https://github.com/jtschwar/projection_refinement.git \
+  && pip install numpy cython six scipy pybind11 matplotlib tqdm h5py scikit-image 
+
+# Build astra
+# The sed line adds the path to astra in the Makefile
+# This does not install astra as a module. Need to use --with-install-type=module for that
+RUN cd /tomo_TV/thirdparty/astra-toolbox/build/linux \
+  && ./autogen.sh \
+  && ./configure --with-cuda=/usr/local/cuda --with-python --with-install-type=prefix --prefix=/tomo_TV/thirdparty/astra-toolbox \
+  && sed -i "508s/$/  --prefix=\/tomo_TV\/thirdparty\/astra-toolbox /" Makefile \
+  && make all \
+  && make install
+
+# Make the shared library
+RUN cd /tomo_TV/gpu_3D/Utils \
+  && make shared_library
+
+# Overwrite make.inc with proper paths written in.
+ADD make_gpu.inc /tomo_TV/gpu_3D/Utils/make.inc
+
+RUN cd /tomo_TV/gpu_3D/Utils \ 
+  && make astra_ctvlib
+
+ENV LD_LIBRARY_PATH=/tomo_TV/thirdparty/astra-toolbox/lib:/tomo_TV/gpu_3D/Utils:$LD_LIBRARY_PATH
+ENV PYTHONPATH=/tomo_TV/thirdparty/astra/lib/python3/site-packages/:/tomo_TV/gpu_3D/Utils:/tomo_TV
+
+# Compile fused multimodal
+ADD make_fused.inc /tomo_TV/fused_multi_modal/Utils/make.inc
+
+RUN cd /tomo_TV/fused_multi_modal/Utils \
+ && make
+
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/tomo_TV/fused_multi_modal/Utils
+
+# Ensure packages work with NERSC Jupyter
+RUN pip install -U ipykernel==6.28 ipympl==0.9.3 matplotlib>=3.8.0 ipywidgets==8.1.1 cupy-cuda11x
+
+# CLone my fork. This makes sure that the new fork is cloned for every docker build
+ADD https://api.github.com/repos/ercius/projection_refinement/git/refs/heads/general_updates version.json
+RUN git clone -b general_updates https://github.com/ercius/projection_refinement.git pae_projection_refinement \
+  && cd pae_projection_refinement \
+#  && git checkout general_updates \
+  && pip install -e .
+

--- a/docker/make_fused.inc
+++ b/docker/make_fused.inc
@@ -1,0 +1,8 @@
+CXX = g++ -fPIC -fopenmp
+MPXX = mpicxx -fPIC -fopenmp
+CUDAXX = nvcc -shared -Xcompiler -fPIC -c
+CXXFLAGS = -O3 -Wno-div-by-zero -shared -std=c++11  `python3 -m pybind11 --includes`
+EIGEN = -I /tomo_TV/thirdparty/eigen
+ASTRA = -DASTRA_CUDA -I /tomo_TV/thirdparty/astra-toolbox -I /tomo_TV/thirdparty/astra-toolbox/include
+ASTRA_LIB = -L /tomo_TV/thirdparty/astra-toolbox/lib/ -lastra
+CUDA = -I /usr/local/cuda/include -L /usr/local/cuda/lib64 -lcudart -lz

--- a/docker/make_gpu.inc
+++ b/docker/make_gpu.inc
@@ -1,0 +1,10 @@
+CXX = g++ -fPIC -fopenmp
+MPXX = mpicxx -fPIC -fopenmp
+CUDAXX = nvcc -shared -Xcompiler -fPIC -c
+CXXFLAGS = -O3 -Wno-div-by-zero -shared -std=c++11 `python3 -m pybind11 --includes`
+EIGEN = -I /tomo_TV/thirdparty/eigen
+ASTRA = -DASTRA_CUDA -I /tomo_TV/thirdparty/astra-toolbox -I /tomo_TV/thirdparty/astra-toolbox/include
+ASTRA_LIB = -L /tomo_TV/thirdparty/astra-toolbox/lib/ -lastra
+CUDA = -I /usr/local/cuda/include -L /usr/local/cuda/lib64 -lcudart -lz
+HDF5_INC = -I /path/to/HDF5/include
+HDF5_LIBS= -L /path/to/HDF5/lib -lhdf5 -lhdf5_hl


### PR DESCRIPTION
This PR adds a docker file to build astra, the gpu 3d and fused multi modal codes. The docker file will also include the projection_refine code (currently from my fork). The docker file can be accessed on dockerhub at `peterercius/tomo_tv:latest`.